### PR TITLE
removed prefix for env variables and added docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Run server
 
     $ npm start
 
+## Additional startup configuration
+
+You can configure port, logfile location, etc using the [config module](lib/config.js) or by specifying environment variables when starting. 
+
+	$ HTTP_PORT=1337 LOG_FILE_NAME=~/mylogs/pvw npm start
+
 # Where to get help
 
 Create a github issue, or contact sveinung.rosaker@finn.no.

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,13 +13,13 @@ var conf = convict({
         doc: 'Node port',
         format: 'port',
         'default': 8000,
-        env: 'PASTIES_HTTP_PORT'
+        env: 'HTTP_PORT'
     },
     logFileName: {
         doc: 'Log file location',
         format: '*',
         'default': './logs/' + pckage.name,
-        env: 'PASTIES_LOG_FILE_NAME'
+        env: 'LOG_FILE_NAME'
     }
 });
 

--- a/server.js
+++ b/server.js
@@ -417,4 +417,4 @@ server.route({
 
 server.start();
 
-log.info(pack.name, 'v' + pack.version, 'started on port', PORT);
+log.info(pack.name, 'v' + pack.version, 'started on port', PORT, 'logs at', config.get('logFileName'));


### PR DESCRIPTION
removed the pasties prefix for the env config names, it is not needed.
