### PR TITLE
Add formats.schibsted.js

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -2,7 +2,8 @@ var domready = require('domready');
 var events = require('dom-events');
 var getManager = require('gardr-host');
 
-var addClass = require('./lib/classes.js').addClass;
+var klass = require('./lib/classes.js');
+var addClass = klass.addClass;
 
 domready(function () {
 
@@ -15,6 +16,7 @@ domready(function () {
     // initToggleAdvanced();
     initReplayBannerControllers();
     initPreview(options);
+    expandableFormats();
 });
 
 var expandable = require('./lib/expandable.js');
@@ -24,6 +26,22 @@ function initExpandables(){
         return;
     }
     expandable(buttons);
+}
+
+function expandableFormats() {
+    var els = document.querySelectorAll('.expand-button');
+
+    function handler(e) {
+        if (e.currentTarget.parentNode.nextElementSibling) {
+            klass.toggleClass(e.currentTarget.parentNode.nextElementSibling, 'hidden');
+        }
+        e.preventDefault();
+        e.stopPropagation();
+    }
+
+    Array.prototype.slice.call(els).forEach(function(el){
+        events.on(el, 'click', handler);
+    });
 }
 
 

--- a/config/formats.finn.js
+++ b/config/formats.finn.js
@@ -1,5 +1,5 @@
 module.exports = [{
-    'name': 'FINN',
+    'name': 'FINN 2014',
     'logo': 'http://nyapp.finn.no/assets/logo.png',
     'meta': ['mobile', 'tablet', 'desktop'],
     'subFormats': {

--- a/config/formats.js
+++ b/config/formats.js
@@ -1,6 +1,6 @@
 module.exports = [{
     'name': 'inma',
-    'title': 'Industry standard – HTML Responsive ads',
+    'title': 'Industry standard - HTML Responsive ads',
     'logo': 'http://www.brandsoftheworld.com/sites/default/files/styles/logo-thumbnail/public/092011/inma_green.gif',
     'meta': ['mobile'],
     'config': {
@@ -22,6 +22,6 @@ module.exports = [{
     }]
 }];
 
-['finn', 'vg', 'storby'].forEach(function(key){
+['schibsted'/*, 'finn', 'vg', 'storby'*/].forEach(function(key){
     module.exports.push.apply(module.exports, require('./formats.' + key + '.js'))
 });

--- a/config/formats.schibsted.js
+++ b/config/formats.schibsted.js
@@ -1,16 +1,17 @@
 module.exports = [{
-    'name': 'Schibsted 2015',
+    'name': 'schibsted-2015',
+    'title': 'Schibsted 2015',
     'logo': 'http://www.schibsted.com/Global/LogoTypes/Logos%202014/SMG_Small_2014_RGB.png',
     'meta': ['mobile', 'tablet', 'desktop'],
     'sites': [{
         'name': 'FINN.no',
-        'logo': 'finn.png'
+        'logo': 'http://nyapp.finn.no/assets/logo.png'
     }, {
         'name': 'VG',
-        'logo': 'vg.png'
+        'logo': 'http://1.vgc.no/vgnett-prod/img/vgLogoMobile.png'
     }, {
         'name': 'Storby',
-        'logo': 'storby.png'
+        'logo': 'http://www.storbyinfo.no/wp-content/uploads/2013/11/logo.png'
     }],
     'subFormats': {
         'non-strict': {
@@ -80,6 +81,3 @@ module.exports = [{
         'height': 500
     }]
 }];
-
-
-

--- a/config/formats.storby.js
+++ b/config/formats.storby.js
@@ -1,7 +1,7 @@
 var logo = "http://www.storbyinfo.no/wp-content/uploads/2013/11/logo.png";
 module.exports = [{
         "name": "storby-mobil",
-        "title": "Storby Mobil",
+        "title": "Storby Mobil 2014",
         "logo": logo,
         "meta": [
             "mobile"

--- a/config/formats.vg.js
+++ b/config/formats.vg.js
@@ -1,6 +1,8 @@
-var logo = 'http://1.vgc.no/vgnett-prod/img/vgLogoMobile.png'
+var logo = 'http://1.vgc.no/vgnett-prod/img/vgLogoMobile.png';
+
 module.exports = [{
     'name': 'VG Mobil',
+    'title': 'VG Mobil 2014',
     'logo': logo,
     'meta': ['mobile'],
     'config': {
@@ -23,6 +25,7 @@ module.exports = [{
     }]
 }, {
     'name': 'VG Tablet',
+    'title': 'VG Tablet 2014',
     'logo': logo,
     'meta': ['tablet'],
     'config': {

--- a/lib/routes/frontpage.js
+++ b/lib/routes/frontpage.js
@@ -172,6 +172,7 @@ internals.requestHandler = function (request, reply) {
 
         return reply.view('formatselector.html', prepare({
             'formats': current.formats.map(internals.createFormatter(current, params)),
+            'sites': current.sites,
             'formatId': params.formatId,
             'formatSubId': params.formatSubId
         }, request, reply));

--- a/templates/formatselector.html
+++ b/templates/formatselector.html
@@ -1,12 +1,22 @@
 <h1>Select <small>size / format</small> <span class="pull-right">{{formatId}}</span></h1>
+
 <div class="list-group">
     {{#formats}}
         <a href="{{link}}" class="list-group-item" title="{{description}}">
-            <strong>{{title}}</strong>
-            {{#description}}
-                <p>{{.}}</p>
-            {{/description}}
-            {{#isMultipleFormat}}
+            <div>{{description}} (<small><strong>{{title}}</strong></small>)
+
+                <button class="btn btn-default btn-xs pull-right expand-button">
+                    <span class="glyphicon glyphicon-plus"></span>
+                </button>
+
+                {{#format.excludeSite}}
+                    <small class="pull-right">(except {{.}})</small>
+                {{/format.excludeSite}}
+            </div>
+
+            <div class="hidden expand-area">
+                <br />
+                {{#isMultipleFormat}}
                 <div class="wrap-format" style="width:{{width}};height:{{height}};">
 
                     <div class="wrap-format-inner2" style="width:{{width2}};height:{{height2}}">
@@ -16,15 +26,22 @@
                         <h2>{{title1}}</h2>
                     </div>
                     <h4>Viewport</h3>
-                </div>
-            {{/isMultipleFormat}}
+                    </div>
+                    {{/isMultipleFormat}}
 
-            {{^isMultipleFormat}}
-                <div class="wrap-format" style="width:{{width1}};height:{{height1}};" >
-                    <br />
-                    <h1 class="text-center" style="margin-top:{{topMargin}};">{{title}}</h1>
-                </div>
-            {{/isMultipleFormat}}
+                    {{^isMultipleFormat}}
+                    <div class="wrap-format" style="width:{{width1}};height:{{height1}};" >
+                        <br />
+                        <h1 class="text-center" style="margin-top:{{topMargin}};">{{title}}</h1>
+                    </div>
+                    {{/isMultipleFormat}}
+            </div>
         </a>
     {{/formats}}
+</div>
+<div class="text-center">
+    {{#sites}}
+        <img style="max-width:155px;max-height:75px;" src="{{logo}}" title="{{name}}"></img>
+        &nbsp;
+    {{/sites}}
 </div>

--- a/templates/siteselector.html
+++ b/templates/siteselector.html
@@ -3,16 +3,25 @@
     {{#formats}}
     <a href="{{base}}formats/{{name}}/" class="list-group-item">
         {{#logo}}
-            <img src="{{.}}" alt="{{name}}" height="50" />
+            <img src="{{.}}" alt="{{name}}" height="40" />
         {{/logo}}
 
-        {{title}}{{^title}}{{name}}{{/title}}
-        {{#meta}}
-            <span class="meta-{{.}}" title="{{.}}">{{.}}</span>
-        {{/meta}}
+
+
+        {{#sites}}
+            <span style="margin:5px 0;" class="pull-right" >
+                <img style="margin-left:10px;max-width:175px;max-height:30px;" src="{{logo}}" title="{{title}}{{name}}"></img>
+            </span>
+        {{/sites}}
+        {{^sites}}
+            <br />
+            {{title}}{{^title}}{{name}}{{/title}}
+        {{/sites}}
+
+
     </a>
     {{/formats}}
     <a href="{{newFormatUrl}}" taget="_blank" class="list-group-item text-center selected">
-       Add another format?
+       Add another format? <small>(required github user)</small>
     </a>
 </div>


### PR DESCRIPTION
Adding the formats for Schibsted in 2015. Included some new config
options that need to be developed. Sites, to display what sites support
the given format, and excludeSite, to remove sites from a given format.
